### PR TITLE
RDFKIT-90 Fix the string explicit switch

### DIFF
--- a/etc/git-hook/pre-commit
+++ b/etc/git-hook/pre-commit
@@ -180,8 +180,7 @@ __log_config__
       --target-format rdf-xml \
       --use-dtd-subset \
       --inline-blank-nodes \
-      --infer-base-iri \
-      --string-data-typing explicit 
+      --infer-base-iri
     rc=$?
     set +x
 


### PR DESCRIPTION
Fix the keys that need to be sent to the rdf-toolkit for serializing; having to do with xsd:string for labels. 