### PR TITLE
Don't use shorthand for rdf:type in subjects and objects.

### DIFF
--- a/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedJsonLdWriter.java
+++ b/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedJsonLdWriter.java
@@ -436,7 +436,8 @@ public class SortedJsonLdWriter extends SortedRdfWriter {
     }
 
     protected void writePredicate(Writer out, IRI predicate) throws Exception {
-        writeIri(out, predicate);
+        out.write(convertVerbIriToString(predicate, useGeneratedPrefixes,
+                                         false, true));
     }
 
     protected void writeIri(Writer out, IRI iri) throws Exception {

--- a/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedRdfWriter.java
+++ b/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedRdfWriter.java
@@ -568,7 +568,7 @@ public abstract class SortedRdfWriter extends AbstractRDFWriter {
         }
     }
 
-    protected String convertIriToString(IRI iri,
+    protected String convertVerbIriToString(IRI iri,
                                         boolean useGeneratedPrefixes,
                                         boolean useTurtleQuoting,
                                         boolean useJsonLdQuoting) throws Exception {
@@ -576,6 +576,14 @@ public abstract class SortedRdfWriter extends AbstractRDFWriter {
             if (useTurtleQuoting) { return "a"; }
             if (useJsonLdQuoting) { return "@type"; }
         }
+        return convertIriToString(iri, useGeneratedPrefixes,
+                                  useTurtleQuoting, useJsonLdQuoting);
+    }
+
+    protected String convertIriToString(IRI iri,
+                                        boolean useGeneratedPrefixes,
+                                        boolean useTurtleQuoting,
+                                        boolean useJsonLdQuoting) throws Exception {
         if (ShortIriPreferences.PREFIX.equals(shortIriPreference)) {
             // return the IRI out as a QName if possible.
             QName qname = convertIriToQName(iri, useGeneratedPrefixes);

--- a/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedTurtleWriter.java
+++ b/src/main/java/org/edmcouncil/rdf_toolkit/writer/SortedTurtleWriter.java
@@ -348,7 +348,12 @@ public class SortedTurtleWriter extends SortedRdfWriter {
     }
 
     protected void writePredicate(Writer out, IRI predicate) throws Exception {
-        writeIri(out, predicate);
+        out.write(
+            convertVerbIriToString(
+                predicate,
+                useGeneratedPrefixes,
+                true,
+                false));
     }
 
     protected void writeIri(Writer out, IRI iri) throws Exception {


### PR DESCRIPTION
This is needed in order to be able to reference `rdf:type` as an object, e.g. in SHACL rules.